### PR TITLE
Add role_name to launchTool to specify Instructor or Viewer roles in LTI call

### DIFF
--- a/classes/connection/class.PanoptoLTIHandler.php
+++ b/classes/connection/class.PanoptoLTIHandler.php
@@ -69,17 +69,19 @@ class PanoptoLTIHandler
     /**
      * @throws PanoptoException
      */
-    public static function launchTool($object, $showIframe = false): string
+    public static function launchTool($object, $showIframe = false,  $isInstructor = false): string
     {
         global $DIC;
         $launch_url = 'https://' . PanoptoConfig::get('hostname') . '/Panopto/BasicLTI/BasicLTILanding.aspx';
         $key = PanoptoConfig::get('instance_name');
-        $secret = PanoptoConfig::get('application_key');
+	$secret = PanoptoConfig::get('application_key');
+	$role_name = $isInstructor ? "Instructor" : "Viewer";
+
 
 
         $launch_data = [
             "user_id" => PanoptoUtils::getUserIdentifier(),
-            "roles" => "Instructor",
+            "roles" => $role_name,
             "resource_link_id" => $object->getFolderExtId(),
             "resource_link_title" => PanoptoUtils::getExternalIdOfObjectById($object->getFolderExtId()),
             "lis_person_name_full" => str_replace("'", "`", $DIC->user()->getFullname()),

--- a/classes/ui/user/class.ManageVideosUI.php
+++ b/classes/ui/user/class.ManageVideosUI.php
@@ -45,7 +45,7 @@ class ManageVideosUI
         global $DIC;
 
         $this->pl = ilPanoptoPlugin::getInstance();
-        $html = PanoptoLTIHandler::launchTool($object, true);
+        $html = PanoptoLTIHandler::launchTool($object, true, true);
         $DIC['tpl']->addCss($this->pl->getDirectory() . '/templates/default/waiter.css');
         $DIC['tpl']->addJavaScript($this->pl->getDirectory() . '/js/waiter.js');
         $DIC['tpl']->addOnLoadCode('$("#lti_form").submit();');

--- a/classes/ui/user/class.UserContentMainUI.php
+++ b/classes/ui/user/class.UserContentMainUI.php
@@ -180,7 +180,7 @@ class UserContentMainUI
             $tpl->parseCurrentBlock();
         }
 
-        $lti_form = PanoptoLTIHandler::launchTool($panoptoObject);
+        $lti_form = PanoptoLTIHandler::launchTool($panoptoObject, false, false);
 
         $this->tpl->addCss($this->pl->getDirectory() . '/templates/default/content_list.css');
         $this->tpl->addJavaScript($this->pl->getDirectory() . '/templates/js/Panopto.js');


### PR DESCRIPTION
- Added `role_name` parameter to `launchTool` function to accurately assign Instructor or Viewer roles during LTI calls.
- Prevents all Viewer roles from defaulting to Instructor roles in Panopto when loading videos.
- Ensures correct role assignment to maintain appropriate permissions and access levels.